### PR TITLE
Upgrade github actions & Enable arm builds

### DIFF
--- a/.github/workflows/docker-image-testing.yml
+++ b/.github/workflows/docker-image-testing.yml
@@ -2,9 +2,9 @@ name: Build and push pgtuned images
 
 on:
   push:
-    branches: [ dev ]
+    branches: [dev]
   pull_request:
-    branches: [ dev ]
+    branches: [dev]
 
 jobs:
   build:
@@ -83,19 +83,26 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.12.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build docker image
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             POSTGRES_VERSION=${{ matrix.postgres_version }}
             POSTGIS_VERSION=${{ matrix.postgis_version }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Build and push pgtuned images
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -83,19 +83,26 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.12.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build docker image
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             POSTGRES_VERSION=${{ matrix.postgres_version }}
             POSTGIS_VERSION=${{ matrix.postgis_version }}


### PR DESCRIPTION
Hello @esgn and thanks for your project. The main purpose of this PR is to bring support of arm64 to the docker image, but also I've updated the rest github actions to the latest versions.
I've [tested these changes](https://github.com/nkt/pgtuned/actions/runs/6535649577) in my fork with the latest versions of postgres. Hope it will work with the rest of it.