### PR TITLE
fix: no space accepted around = when assigning variables

### DIFF
--- a/pgtune.sh
+++ b/pgtune.sh
@@ -177,7 +177,7 @@ set_maintenance_work_mem() {
   local mem_limit=$(( 2 * $GB / $KB ))
   if [ "$maintenance_work_mem" -gt "$mem_limit" ]
   then
-    maintenance_work_mem = $mem_limit
+    maintenance_work_mem=$mem_limit
   fi
 }
 


### PR DESCRIPTION
Hi!
I noticed a bug when running the pgtune.sh script and found that spaces was used around equal sign when assigning a variable.
This is not possible in bash.

This is fixed in this pull request.

Best regards

Mikael
